### PR TITLE
Clarify multilingual document links

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@ title: A Project of Internews
 							<div class="4u 12u$(medium)">
 								<p>You can <a href="/guide">explore the framework online</a> and download the overview and the full guide of the SAFETAG audit here:</p>
 								<ul>
-									<li><a href="https://github.com/SAFETAG/SAFETAG/releases/download/v0.4/SAFETAG.Overview.English.pdf">Overview</a> (<a href="https://github.com/SAFETAG/SAFETAG/releases/download/v0.4/SAFETAG.Overview.Espanol.pdf">En Español</a>)</li>
-								  <li><a href="https://github.com/SAFETAG/SAFETAG/files/1278308/SAFETAG-FullGuide_Sep2017.pdf">Full Guide</a> (<a href="https://github.com/SAFETAG/SAFETAG/releases/download/v0.4/SAFETAG.Full.guide.Espanol.pdf">En Español</a>)</li>
+									<li>Overview (<a href="https://github.com/SAFETAG/SAFETAG/releases/download/v0.4/SAFETAG.Overview.English.pdf">In English</a>) (<a href="https://github.com/SAFETAG/SAFETAG/releases/download/v0.4/SAFETAG.Overview.Espanol.pdf">En Español</a>)</li>
+								  <li>Full Guide (<a href="https://github.com/SAFETAG/SAFETAG/files/1278308/SAFETAG-FullGuide_Sep2017.pdf">In English</a>) (<a href="https://github.com/SAFETAG/SAFETAG/releases/download/v0.4/SAFETAG.Full.guide.Espanol.pdf">En Español</a>)</li>
 								</ul>
 							</div>
 							<div class="4u$ 12u$(medium)">


### PR DESCRIPTION
User quote: "I downloaded the guide but it's only in Spanish". Users were thinking resources were ONLY in Spanish because of the display of the link text: Overview (En Espanol). Switched it to Overview (In English) (En Espanol)